### PR TITLE
Complete revamp to support PHP 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The original `php.ini` files are _never_ touched by this role.
 Instead a `99-customization.ini` file is placed in the appropriate `conf.d` directories.
 These customization files will be filled with the [INI directives](https://secure.php.net/manual/en/ini.list.php) you specify with the following role variables.
 
+### INI
+
 Global INI directives, which configure all of CLI, Apache2, CGI and FPM:
 
     php7_ini_directives_global: {}
@@ -58,6 +60,24 @@ The result is the same as if configured in the following way:
       session.sid_bits_per_character: 4   # 7.1 and up
       session.sid_length: 64              # 7.1 and up
       session.use_strict_mode: yes
+
+### Extensions
+
+Install additional PHP extensions:
+
+    php7_extensions: []
+    php7_versioned_extensions: []
+
+For example, to install the packages `php-apcu`, `php7.X-curl` and `php7.X-mysql`:
+
+    php7_extensions:
+      - apcu
+
+    php7_versioned_extensions:
+      - curl
+      - mysql
+
+Extension specific INI directives can be specified the same way any other, see the **INI** section above.
 
 ### FPM
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,152 @@
-PHP
-========
+PHP7
+====
 
-Install latest PHP version in DotDeb repository
+Install PHP version 7.X from [deb.sury.org](https://deb.sury.org/).
 
 Requirements
 ------------
 
-Debian Jessie with the package python-pycurl and python-software-properties installed.
+This role is tailored towards Debian Jessie.
+
+The packages `python-apt` (or `python3-apt`) must be installed.
 
 Role Variables
 --------------
 
-There are as many role variables as PHP.ini variables. All of them can be set, but the defaults
-are adjusted according to [iniscan](https://github.com/psecio/iniscan) security best practices.
+All role variables are displayed with their default value.
+
+Specify the version of PHP you want to use (`7.0` or `7.1`):
+
+    php7_version: 7.1
+
+CLI is always installed. You can also install the Apache2 module, CGI binary and/or FPM binary:
+
+    php7_enable_apache: no
+    php7_enable_cgi:    no
+    php7_enable_fpm:    no
+
+Files for module development can be installed too:
+
+    php7_enable_dev: no
+
+The original `php.ini` files are _never_ touched by this role.
+Instead a `99-customization.ini` file is placed in the appropriate `conf.d` directories.
+These customization files will be filled with the [INI directives](https://secure.php.net/manual/en/ini.list.php) you specify with the following role variables.
+
+Global INI directives, which configure all of CLI, Apache2, CGI and FPM:
+
+    php7_ini_directives_global: {}
+
+Specific INI directives:
+
+    php7_ini_directives_cli:    {}
+    php7_ini_directives_apache: {}
+    php7_ini_directives_cgi:    {}
+    php7_ini_directives_fpm:    {}
+
+This role sets a couple of INI directives that are viewed as best practices.
+The result is the same as if configured in the following way:
+
+    php7_ini_directives_global:
+      allow_url_fopen: no
+      disable_functions: "exec, passthru, shell_exec, system, proc_open, popen, curl_exec, curl_multi_exec"
+      expose_php: no
+      session.cookie_httponly: yes
+      session.cookie_secure: yes
+      session.hash_bits_per_character: 4  # 7.0 only
+      session.hash_function: sha256       # 7.0 only
+      session.sid_bits_per_character: 4   # 7.1 and up
+      session.sid_length: 64              # 7.1 and up
+      session.use_strict_mode: yes
+
+### FPM
+
+The following variables can be used to configure PHP FPM:
+
+    php7_fpm_pid: "/run/php/php{{ php7_version }}-fpm.pid"
+    php7_fpm_error_log: "/var/log/php{{ php7_version }}-fpm.log"
+    php7_fpm_log_level: warning
+    php7_fpm_syslog_facility: ~
+    php7_fpm_syslog_ident: ~
+    php7_fpm_emergency_restart_threshold: 0
+    php7_fpm_emergency_restart_interval: 0
+    php7_fpm_process_control_timeout: 0
+    php7_fpm_process_max: 0
+    php7_fpm_process_priority: ~
+    php7_fpm_daemonize: yes
+    php7_fpm_rlimit_files: ~
+    php7_fpm_rlimit_core: ~
+    php7_fpm_events_mechanism: epoll
+    php7_fpm_systemd_interval: 10
+
+By default a standard pool is configured as well:
+
+    php7_fpm_pool_enabled: yes
+
+The pool name will determine the filename (with `.conf` appended):
+
+    php7_fpm_pool_name: www
+
+The following variables configure that standard pool (when enabled)
+
+    php7_fpm_pool_user: www-data
+    php7_fpm_pool_group: www-data
+    php7_fpm_pool_listen: "/run/php/php{{ php7_version }}-fpm.sock"
+    php7_fpm_pool_listen_backlog: 512
+    php7_fpm_pool_listen_owner: "{{ php7_fpm_pool_user }}"
+    php7_fpm_pool_listen_group: "{{ php7_fpm_pool_group }}"
+    php7_fpm_pool_listen_mode: "0660"
+    php7_fpm_pool_listen_acl_users: ~
+    php7_fpm_pool_listen_acl_groups: ~
+    php7_fpm_pool_listen_allowed_clients: ~
+    php7_fpm_pool_pm: dynamic
+    php7_fpm_pool_pm_max_children: 5
+    php7_fpm_pool_pm_start_servers: 2
+    php7_fpm_pool_pm_min_spare_servers: 1
+    php7_fpm_pool_pm_max_spare_servers: 3
+    php7_fpm_pool_pm_process_idle_timeout: 10s
+    php7_fpm_pool_pm_max_requests: 512
+    php7_fpm_pool_status_path: /status
+    php7_fpm_pool_ping_path: /ping
+    php7_fpm_pool_ping_response: pong
+    php7_fpm_pool_access_log: ~
+    php7_fpm_pool_access_format: ~
+    php7_fpm_pool_slowlog: ~
+    php7_fpm_pool_request_slowlog_timeout: 0
+    php7_fpm_pool_request_terminate_timeout: 0
+    php7_fpm_pool_rlimit_files: ~
+    php7_fpm_pool_rlimit_core: ~
+    php7_fpm_pool_chroot: ~
+    php7_fpm_pool_chdir: /var/www
+    php7_fpm_pool_catch_workers_output: yes
+    php7_fpm_pool_clear_env: yes
+    php7_fpm_pool_security_limit_extensions: .php
+    php7_fpm_pool_env: {}
+    php7_fpm_pool_php_admin_value: {}
+    php7_fpm_pool_php_value: {}
 
 Dependencies
 ------------
 
-Depends on f500.repo_dotdeb.
+None.
 
 Example Playbook
--------------------------
+----------------
 
     - hosts: servers
       roles:
-         - { role: f500.php, php_error_reporting: "E_ALL" }
+        - { role: f500.php7, php7_version: 7.1, php7_enable_fpm: yes }
 
 License
 -------
 
-LGPL
+Copyright (C) 2017 Future500 B.V.
+
+[LGPL-3.0](https://github.com/f500/ansible-php7/blob/master/COPYING.LESSER)
 
 Author Information
 ------------------
 
-Jasper N. Brouwer, jasper@nerdsweide.nl
+Jasper N. Brouwer, jasper@future500.nl
 
-Ramon de la Fuente, ramon@delafuente.nl
+Ramon de la Fuente, ramon@future500.nl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,339 +1,81 @@
 ---
 
-# CONVENIENCE OPTIONS
+php7_version: 7.1
 
-php_log_dir: "/var/log/php7"
+php7_enable_apache: no
+php7_enable_cgi: no
+php7_enable_fpm: no
 
-php_mysql_global_allow_local_infile: "On"
-php_mysql_global_allow_persistent: "On"
-php_mysql_global_cache_size: 2000
-php_mysql_global_default_host: "localhost"
-php_mysql_global_default_password: ""
-php_mysql_global_default_port: 3306
-php_mysql_global_default_socket: ""
-php_mysql_global_default_user: ""
-php_mysql_global_max_links: -1
-php_mysql_global_max_persistent: -1
+php7_enable_dev: no
 
+php7_ini_directives_default:
+  allow_url_fopen: no
+  disable_functions: "exec, passthru, shell_exec, system, proc_open, popen, curl_exec, curl_multi_exec"
+  expose_php: no
+  session.cookie_httponly: yes
+  session.cookie_secure: yes
+  session.hash_bits_per_character: 4
+  session.hash_function: sha256
+  session.sid_bits_per_character: 4
+  session.sid_length: 64
+  session.use_strict_mode: yes
 
-# PHP.INI SETTINGS
+php7_ini_directives_global: {}
+php7_ini_directives_cli: {}
+php7_ini_directives_apache: {}
+php7_ini_directives_cgi: {}
+php7_ini_directives_fpm: {}
 
-php_allow_url_fopen: "Off"
-php_allow_url_include: "Off"
-# php_arg_separator_input: ";&"
-# php_arg_separator_output: "&amp;"
-php_auto_append_file: ""
-# php_auto_detect_line_endings: "Off"
-php_auto_globals_jit: "On"
-php_auto_prepend_file: ""
-# php_cgi_fix_pathinfo: 1
-# php_cgi_force_redirect: 1
-# php_cgi_nph: 1
-# php_cgi_redirect_status_env: ""
-# php_cgi_rfc2616_headers: 0
-php_default_charset: "UTF-8"
-php_default_mimetype: "text/html"
-php_default_socket_timeout: 60
-php_disable_classes: ""
-php_disable_functions: ""
-php_display_errors: "Off"
-php_display_startup_errors: "Off"
-php_doc_root: ""
-# php_docref_ext: ".html"
-# php_docref_root: "/phpmanual/"
-php_enable_dl: "Off"
-# php_enable_post_data_reading: "Off"
-php_engine: "On"
-# php_error_append_string: "</span>"
-php_error_log: "{{ php_log_dir }}/php_errors.log"
-# php_error_prepend_string: "<span style='color: #ff0000'>"
-php_error_reporting: "E_ALL"
-php_expose_php: "Off"
-# php_extensions: []
-# php_extension_dir: "./"
-# php_fastcgi_impersonate: 1
-# php_fastcgi_logging: 0
-php_file_uploads: On
-# php_from: "john@doe-com"
-# php_highlight_comment: "#FF9900"
-# php_highlight_default: "#0000BB"
-# php_highlight_html   : "#000000"
-# php_highlight_keyword: "#007700"
-# php_highlight_string : "#DD0000"
-php_html_errors: On
-php_ignore_repeated_errors: "Off"
-php_ignore_repeated_source: "Off"
-# php_ignore_user_abort: "On"
-php_implicit_flush: "Off"
-# php_include_path: ".:/php/includes"
-# php_internal_encoding: ""
-# php_input_encoding: ""
-php_log_errors: "On"
-php_log_errors_max_len: 1024
-php_max_execution_time: 30
-php_max_file_uploads: 20
-# php_max_input_nesting_level: 64
-php_max_input_time: 60
-# php_max_input_vars: 1000
-php_memory_limit: "128M"
-# php_open_basedir: ""
-php_output_buffering: 4096
-# php_output_encoding: ""
-# php_output_handler: ""
-php_post_max_size: "8M"
-php_precision: 14
-# php_realpath_cache_size: "16k"
-# php_realpath_cache_ttl: 120
-php_register_argc_argv: "Off"
-php_report_memleaks: "On"
-# php_report_zend_debug: "Off"
-php_request_order: "GP"
-php_serialize_precision: 17
-php_short_open_tag: "Off"
-# php_sys_temp_dir: "/tmp"
-php_track_errors: "Off"
-php_unserialize_callback_func: ""
-php_upload_max_filesize: "2M"
-# php_upload_tmp_dir: ""
-# php_user_agent: "PHP"
-php_user_dir: ""
-# php_user_ini_cache_ttl: 300
-# php_user_ini_filename: ".user.ini"
-php_variables_order: "GPCS"
-# php_windows_show_crt_warning: 0
-# php_xmlrpc_error_number: 0
-# php_xmlrpc_errors: "Off"
-php_zend_enable_gc: "On"
-# php_zend_multibyte: "Off"
-# php_zend_script_encoding: ""
-php_zlib_output_compression: "Off"
-# php_zlib_output_compression_level: -1
-# php_zlib_output_handler: ""
+php7_fpm_pid: "/run/php/php{{ php7_version }}-fpm.pid"
+php7_fpm_error_log: "/var/log/php{{ php7_version }}-fpm.log"
+php7_fpm_log_level: warning
+php7_fpm_syslog_facility: ~
+php7_fpm_syslog_ident: ~
+php7_fpm_emergency_restart_threshold: 0
+php7_fpm_emergency_restart_interval: 0
+php7_fpm_process_control_timeout: 0
+php7_fpm_process_max: 0
+php7_fpm_process_priority: ~
+php7_fpm_daemonize: yes
+php7_fpm_rlimit_files: ~
+php7_fpm_rlimit_core: ~
+php7_fpm_events_mechanism: epoll
+php7_fpm_systemd_interval: 10
 
-# php_assert_active: "On"
-# php_assert_exception: "On"
-# php_assert_bail: "Off"
-# php_assert_callback: 0
-# php_assert_quiet_eval: 0
-# php_assert_warning: "On"
-
-php_bcmath_scale: 0
-
-# php_browscap: "extra/browscap.ini"
-
-php_cli_server_color: "On"
-
-# php_com_allow_dcom: "On"
-# php_com_autoregister_casesensitive: "Off"
-# php_com_autoregister_typelib: "On"
-# php_com_autoregister_verbose: "On"
-# php_com_code_page: ""
-# php_com_typelib_file:
-
-# php_curl_cainfo: ""
-
-# php_date_default_latitude: 31.7667
-# php_date_default_longitude: 35.2333
-# php_date_sunrise_zenith: 90.583333
-# php_date_sunset_zenith: 90.583333
-php_date_timezone: "Europe/Amsterdam"
-
-# php_dba_default_handler: ""
-
-# php_exif_decode_jis_intel   : "JIS"
-# php_exif_decode_jis_motorola: "JIS"
-# php_exif_decode_unicode_intel   : "UCS-2LE"
-# php_exif_decode_unicode_motorola: "UCS-2BE"
-# php_exif_encode_jis: ""
-# php_exif_encode_unicode: "ISO-8859-15"
-
-# php_filter_default: "unsafe_raw"
-# php_filter_default_flags: ""
-
-# php_gd_jpeg_ignore_warning: 0
-
-php_ibase_allow_persistent: 1
-php_ibase_dateformat: "%Y-%m-%d"
-# php_ibase_default_charset: ""
-# php_ibase_default_db: ""
-# php_ibase_default_password: ""
-# php_ibase_default_user: ""
-php_ibase_max_links: -1
-php_ibase_max_persistent: -1
-php_ibase_timeformat: "%H:%M:%S"
-php_ibase_timestampformat: "%Y-%m-%d %H:%M:%S"
-
-# php_iconv_input_encoding: "ISO-8859-1"
-# php_iconv_internal_encoding: "UTF-8"
-# php_iconv_output_encoding: "UTF-8"
-
-# php_intl_default_locale: ""
-# php_intl_error_level: "E_WARNING"
-
-php_ldap_max_links: -1
-
-php_mail_add_x_header: "On"
-# php_mail_force_extra_parameters: ""
-php_mail_log: "{{ php_log_dir }}/php_mail.log"
-# php_mail_sendmail_from: "me@example.com"
-php_mail_sendmail_path: "/usr/sbin/sendmail"
-php_mail_smtp_host: "localhost"
-php_mail_smtp_port: 25
-
-# php_mbstring_detect_order: "auto"
-# php_mbstring_encoding_translation: "Off"
-# php_mbstring_func_overload: 0
-# php_mbstring_http_input: "UTF-8"
-# php_mbstring_http_output: "pass"
-# php_mbstring_http_output_conv_mimetype: ""
-# php_mbstring_internal_encoding: "UTF-8"
-# php_mbstring_language: "Japanese"
-# php_mbstring_strict_detection: "On"
-# php_mbstring_substitute_character: "none"
-
-# php_mcrypt_algorithms_dir: ""
-# php_mcrypt_modes_dir: ""
-
-php_mysqli_allow_local_infile: "{{ php_mysql_global_allow_local_infile }}"
-php_mysqli_allow_persistent: "{{ php_mysql_global_allow_persistent }}"
-php_mysqli_cache_size: "{{ php_mysql_global_cache_size }}"
-php_mysqli_default_host: "{{ php_mysql_global_default_host }}"
-php_mysqli_default_port: "{{ php_mysql_global_default_port }}"
-php_mysqli_default_pw: "{{ php_mysql_global_default_password }}"
-php_mysqli_default_socket: "{{ php_mysql_global_default_socket }}"
-php_mysqli_default_user: "{{ php_mysql_global_default_user }}"
-php_mysqli_max_links: "{{ php_mysql_global_max_links }}"
-php_mysqli_max_persistent: "{{ php_mysql_global_max_persistent }}"
-php_mysqli_reconnect: "Off"
-
-php_mysqlnd_collect_memory_statistics: "Off"
-php_mysqlnd_collect_statistics: "On"
-# php_mysqlnd_net_cmd_buffer_size: 2048
-# php_mysqlnd_net_read_buffer_size: 32768
-
-# php_oci8_connection_class: ""
-# php_oci8_default_prefetch: 100
-# php_oci8_events: "Off"
-# php_oci8_max_persistent: -1
-# php_oci8_old_oci_close_semantics: "Off"
-# php_oci8_persistent_timeout: -1
-# php_oci8_ping_interval: 60
-# php_oci8_privileged_connect: "Off"
-# php_oci8_statement_cache_size: 20
-
-php_odbc_allow_persistent: "On"
-# php_odbc_birdstep_max_links: -1
-php_odbc_check_persistent: "On"
-php_odbc_default_binmode: 1
-# php_odbc_default_cursortype: ""
-# php_odbc_default_db: ""
-php_odbc_default_lrl: 4096
-# php_odbc_default_pw: ""
-# php_odbc_default_user: ""
-php_odbc_max_links: -1
-php_odbc_max_persistent: -1
-
-# php_opcache_blacklist_filename: ""
-# php_opcache_consistency_checks: 0
-# php_opcache_dups_fix: 0
-php_opcache_enable: 1
-php_opcache_enable_cli: 1
-# php_opcache_enable_file_override: 0
-php_opcache_error_log: "{{ php_log_dir }}/opcache_errors.log"
-php_opcache_fast_shutdown: 1
-# php_opcache_file_cache: ""
-# php_opcache_file_cache_only: 0
-# php_opcache_file_cache_consistency_checks: 1
-# php_opcache_force_restart_timeout: 180
-# php_opcache_huge_code_pages: 1
-# php_opcache_inherited_hack: 1
-php_opcache_interned_strings_buffer: 8
-# php_opcache_log_verbosity_level: 1
-php_opcache_max_accelerated_files: 4000
-# php_opcache_max_file_size: 0
-# php_opcache_max_wasted_percentage: 5
-php_opcache_memory_consumption: 128
-# php_opcache_mmap_base: ""
-# php_opcache_optimization_level: "0xffffffff"
-# php_opcache_preferred_memory_model: ""
-# php_opcache_protect_memory: 0
-# php_opcache_restrict_api: ""
-php_opcache_revalidate_freq: 60
-# php_opcache_revalidate_path: 0
-# php_opcache_save_comments: 1
-# php_opcache_use_cwd: 1
-# php_opcache_validate_timestamps: 1
-
-# php_openssl_cafile = ""
-# php_openssl_capath = ""
-
-# php_pcre_backtrack_limit: 100000
-# php_pcre_recursion_limit: 100000
-# php_pcre_jit: 1
-
-php_pdo_mysql_cache_size: "{{ php_mysql_global_cache_size }}"
-php_pdo_mysql_default_socket: "{{ php_mysql_global_default_socket }}"
-
-# php_pdo_odbc_connection_pooling: "strict"
-# php_pdo_odbc_db2_instance_name: ""
-
-php_pgsql_allow_persistent: "On"
-php_pgsql_auto_reset_persistent: "Off"
-php_pgsql_ignore_notice: 0
-php_pgsql_log_notice: 0
-php_pgsql_max_links: -1
-php_pgsql_max_persistent: -1
-
-# php_phar_cache_list: ""
-# php_phar_readonly: "On"
-# php_phar_require_hash: "On"
-
-php_session_auto_start: 0
-php_session_cache_expire: 180
-php_session_cache_limiter: "nocache"
-php_session_cookie_domain: ""
-php_session_cookie_httponly: 1
-php_session_cookie_lifetime: 0
-php_session_cookie_path: "/"
-php_session_cookie_secure: 1
-php_session_entropy_file: "/dev/urandom"
-# php_session_entropy_length: 32
-php_session_gc_divisor: 1000
-php_session_gc_maxlifetime: 1440
-php_session_gc_probability: 1
-php_session_hash_bits_per_character: 5
-php_session_hash_function: "sha256"
-php_session_name: "PHPSESSID"
-php_session_referer_check: ""
-php_session_save_handler: "files"
-# php_session_save_path: "/tmp"
-php_session_serialize_handler: "php"
-# php_session_upload_progress_cleanup: "On"
-# php_session_upload_progress_enabled: "On"
-# php_session_upload_progress_freq: "1%"
-# php_session_upload_progress_min_freq: "1"
-# php_session_upload_progress_name: "PHP_SESSION_UPLOAD_PROGRESS"
-# php_session_upload_progress_prefix: "upload_progress_"
-php_session_url_rewriter_tags: "a=href,area=href,frame=src,input=src,form=fakeentry"
-php_session_use_cookies: 1
-php_session_use_only_cookies: 1
-php_session_use_strict_mode: 1
-php_session_use_trans_sid: 0
-
-php_soap_wsdl_cache_dir: "/tmp"
-php_soap_wsdl_cache_enabled: 1
-php_soap_wsdl_cache_limit: 5
-php_soap_wsdl_cache_ttl: 86400
-
-php_sql_safe_mode: "Off"
-
-# php_sqlite_assoc_case: 0
-
-# php_sqlite3_extension_dir: ""
-
-# php_sysvshm_init_mem: 10000
-
-php_tidy_clean_output: "Off"
-# php_tidy_default_config: "/usr/local/lib/php/default.tcfg"
-
-php_zend_assertions: -1
+php7_fpm_pool_enabled: yes
+php7_fpm_pool_name: www
+php7_fpm_pool_user: www-data
+php7_fpm_pool_group: www-data
+php7_fpm_pool_listen: "/run/php/php{{ php7_version }}-fpm.sock"
+php7_fpm_pool_listen_backlog: 512
+php7_fpm_pool_listen_owner: "{{ php7_fpm_pool_user }}"
+php7_fpm_pool_listen_group: "{{ php7_fpm_pool_group }}"
+php7_fpm_pool_listen_mode: "0660"
+php7_fpm_pool_listen_acl_users: ~
+php7_fpm_pool_listen_acl_groups: ~
+php7_fpm_pool_listen_allowed_clients: ~
+php7_fpm_pool_pm: dynamic
+php7_fpm_pool_pm_max_children: 5
+php7_fpm_pool_pm_start_servers: 2
+php7_fpm_pool_pm_min_spare_servers: 1
+php7_fpm_pool_pm_max_spare_servers: 3
+php7_fpm_pool_pm_process_idle_timeout: 10s
+php7_fpm_pool_pm_max_requests: 512
+php7_fpm_pool_status_path: /status
+php7_fpm_pool_ping_path: /ping
+php7_fpm_pool_ping_response: pong
+php7_fpm_pool_access_log: ~
+php7_fpm_pool_access_format: ~
+php7_fpm_pool_slowlog: ~
+php7_fpm_pool_request_slowlog_timeout: 0
+php7_fpm_pool_request_terminate_timeout: 0
+php7_fpm_pool_rlimit_files: ~
+php7_fpm_pool_rlimit_core: ~
+php7_fpm_pool_chroot: ~
+php7_fpm_pool_chdir: /var/www
+php7_fpm_pool_catch_workers_output: yes
+php7_fpm_pool_clear_env: yes
+php7_fpm_pool_security_limit_extensions: .php
+php7_fpm_pool_env: {}
+php7_fpm_pool_php_admin_value: {}
+php7_fpm_pool_php_value: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ php7_ini_directives_apache: {}
 php7_ini_directives_cgi: {}
 php7_ini_directives_fpm: {}
 
+php7_extensions: []
+php7_versioned_extensions: []
+
 php7_fpm_pid: "/run/php/php{{ php7_version }}-fpm.pid"
 php7_fpm_error_log: "/var/log/php{{ php7_version }}-fpm.log"
 php7_fpm_log_level: warning

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,11 @@
 ---
 
-- name: restart php-fpm
-  service: name=php7.0-fpm state=restarted
+- name: Restart Apache
+  service:
+    name: apache2
+    state: restarted
+
+- name: Restart PHP FPM
+  service:
+    name: "php{{ php7_version }}-fpm"
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,8 +4,10 @@
   service:
     name: apache2
     state: restarted
+  when: php7_enable_apache
 
 - name: Restart PHP FPM
   service:
     name: "php{{ php7_version }}-fpm"
     state: restarted
+  when: php7_enable_fpm

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,15 +1,14 @@
 ---
+
 galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
-  description: Install latest PHP version in DotDeb repository
+  description: Install PHP version 7.X from deb.sury.org
   company: Future500
-  license: LGPL
-  min_ansible_version: 1.4
+  license: LGPL-3.0
+  min_ansible_version: 2.0
   platforms:
   - name: Debian
     versions:
       - jessie
   categories:
     - web
-dependencies:
-  - f500.repo_dotdeb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,107 @@
 ---
 
-- name: install php7.0-common
-  apt: pkg=php7.0-common state=present
+- name: Validate version value
+  fail:
+    msg: "The value of php7_version must be 7.0 or 7.1"
+  when: php7_version not in [7.0, 7.1]
+
+- name: Install packages needed to use the deb.sury.org repository
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+
+- name: Add the deb.sury.org trusted key
+  apt_key:
+    id: 4A7A714D
+    url: https://packages.sury.org/php/apt.gpg
+
+- name: Add the deb.sury.org repository
+  apt_repository:
+    repo: deb https://packages.sury.org/php/ jessie main
+    update_cache: yes
+
+- name: Install PHP CLI
+  apt:
+    name: "php{{ php7_version }}-cli"
+
+- name: Configure PHP for CLI
+  template:
+    src: php.ini.j2
+    dest: "/etc/php/{{ php7_version }}/cli/conf.d/99-customization.ini"
+  vars:
+    php7_ini_directives: "{{ php7_ini_directives_default | combine(php7_ini_directives_global) | combine(php7_ini_directives_cli) }}"
+
+- name: Install PHP module development files
+  apt:
+    name: "php{{ php7_version }}-dev"
+  when: php7_enable_dev
+
+- name: Install PHP Apache2 module
+  apt:
+    name: "libapache2-mod-php{{ php7_version }}"
+  when: php7_enable_apache
+
+- name: Configure PHP for Apache2
+  template:
+    src: php.ini.j2
+    dest: "/etc/php/{{ php7_version }}/apache2/conf.d/99-customization.ini"
+  vars:
+    php7_ini_directives: "{{ php7_ini_directives_default | combine(php7_ini_directives_global) | combine(php7_ini_directives_apache) }}"
+  notify: Restart Apache
+  when: php7_enable_apache
+
+- name: Install PHP CGI binary
+  apt:
+    name: "php{{ php7_version }}-cgi"
+  when: php7_enable_cgi
+
+- name: Configure PHP for CGI
+  template:
+    src: php.ini.j2
+    dest: "/etc/php/{{ php7_version }}/cgi/conf.d/99-customization.ini"
+  vars:
+    php7_ini_directives: "{{ php7_ini_directives_default | combine(php7_ini_directives_global) | combine(php7_ini_directives_cgi) }}"
+  when: php7_enable_cgi
+
+- name: Install PHP FPM binary
+  apt:
+    name: "php{{ php7_version }}-fpm"
+  when: php7_enable_fpm
+
+- name: Configure PHP for FPM
+  template:
+    src: php.ini.j2
+    dest: "/etc/php/{{ php7_version }}/fpm/conf.d/99-customization.ini"
+  vars:
+    php7_ini_directives: "{{ php7_ini_directives_default | combine(php7_ini_directives_global) | combine(php7_ini_directives_fpm) }}"
+  notify: Restart PHP FPM
+  when: php7_enable_fpm
+
+- name: Configure FPM
+  template:
+    src: php-fpm.conf.j2
+    dest: "/etc/php/{{ php7_version }}/fpm/php-fpm.conf"
+  notify: Restart PHP FPM
+  when: php7_enable_fpm
+
+- name: Configure the standard pool for FPM
+  template:
+    src: php-fpm-pool.conf.j2
+    dest: "/etc/php/{{ php7_version }}/fpm/pool.d/{{ php7_fpm_pool_name }}.conf"
+  notify: Restart PHP FPM
+  when: php7_enable_fpm and php7_fpm_pool_enabled
+
+- name: Remove the standard pool for FPM
+  file:
+    path: "/etc/php/{{ php7_version }}/fpm/pool.d/{{ php7_fpm_pool_name }}.conf"
+    state: absent
+  notify: Restart PHP FPM
+  when: php7_enable_fpm and not php7_fpm_pool_enabled
+
+- name: Enable the FPM service
+  service:
+    name: "php{{ php7_version }}-fpm"
+    enabled: yes
+  when: php7_enable_fpm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,3 +105,19 @@
     name: "php{{ php7_version }}-fpm"
     enabled: yes
   when: php7_enable_fpm
+
+- name: Install PHP extensions
+  apt:
+    name: "php-{{ item }}"
+  with_items: "{{ php7_extensions }}"
+  notify:
+    - Restart Apache
+    - Restart PHP FPM
+
+- name: Install versioned PHP extensions
+  apt:
+    name: "php{{ php7_version }}-{{ item }}"
+  with_items: "{{ php7_versioned_extensions }}"
+  notify:
+    - Restart Apache
+    - Restart PHP FPM

--- a/templates/php-fpm-pool.conf.j2
+++ b/templates/php-fpm-pool.conf.j2
@@ -1,0 +1,91 @@
+[{{ php7_fpm_pool_name }}]
+
+user = {{ php7_fpm_pool_user }}
+group = {{ php7_fpm_pool_group }}
+
+listen = {{ php7_fpm_pool_listen }}
+
+listen.backlog = {{ php7_fpm_pool_listen_backlog }}
+listen.owner = {{ php7_fpm_pool_listen_owner }}
+listen.group = {{ php7_fpm_pool_listen_group }}
+listen.mode = {{ php7_fpm_pool_listen_mode }}
+
+{% if php7_fpm_pool_listen_acl_users is not none %}
+listen.acl_users = {{ php7_fpm_pool_listen_acl_users }}
+{% endif %}
+{% if php7_fpm_pool_listen_acl_groups is not none %}
+listen.acl_groups = {{ php7_fpm_pool_listen_acl_groups }}
+{% endif %}
+{% if php7_fpm_pool_listen_allowed_clients is not none %}
+listen.allowed_clients = {{ php7_fpm_pool_listen_allowed_clients }}
+{% endif %}
+
+pm = {{ php7_fpm_pool_pm }}
+pm.max_children = {{ php7_fpm_pool_pm_max_children }}
+pm.start_servers = {{ php7_fpm_pool_pm_start_servers }}
+pm.min_spare_servers = {{ php7_fpm_pool_pm_min_spare_servers }}
+pm.max_spare_servers = {{ php7_fpm_pool_pm_max_spare_servers }}
+pm.process_idle_timeout = {{ php7_fpm_pool_pm_process_idle_timeout }}
+pm.max_requests = {{ php7_fpm_pool_pm_max_requests }}
+
+{% if php7_fpm_pool_status_path is not none %}
+pm.status_path = {{ php7_fpm_pool_status_path }}
+{% endif %}
+{% if php7_fpm_pool_ping_path is not none %}
+ping.path = {{ php7_fpm_pool_ping_path }}
+{% endif %}
+{% if php7_fpm_pool_ping_response is not none %}
+ping.response = {{ php7_fpm_pool_ping_response }}
+{% endif %}
+
+{% if php7_fpm_pool_access_log is not none %}
+access.log = {{ php7_fpm_pool_access_log }}
+{% endif %}
+{% if php7_fpm_pool_access_format is not none %}
+access.format = {{ php7_fpm_pool_access_format }}
+{% endif %}
+{% if php7_fpm_pool_slowlog is not none %}
+slowlog = {{ php7_fpm_pool_slowlog }}
+{% endif %}
+
+request_slowlog_timeout = {{ php7_fpm_pool_request_slowlog_timeout }}
+request_terminate_timeout = {{ php7_fpm_pool_request_terminate_timeout }}
+
+{% if php7_fpm_pool_rlimit_files is not none %}
+rlimit_files = {{ php7_fpm_pool_rlimit_files }}
+{% endif %}
+{% if php7_fpm_pool_rlimit_core is not none %}
+rlimit_core = {{ php7_fpm_pool_rlimit_core }}
+{% endif %}
+{% if php7_fpm_pool_chroot is not none %}
+chroot = {{ php7_fpm_pool_chroot }}
+{% endif %}
+
+chdir = {{ php7_fpm_pool_chdir }}
+catch_workers_output = {{ php7_fpm_pool_catch_workers_output }}
+clear_env = {{ php7_fpm_pool_clear_env }}
+security.limit_extensions = {{ php7_fpm_pool_security_limit_extensions }}
+
+{% for key, value in php7_fpm_pool_env.iteritems() %}
+env[{{ key }}] = {{ value }}
+{% endfor %}
+
+{% for key, value in php7_fpm_pool_php_admin_value.iteritems() %}
+{% if value is sameas True %}
+php_admin_flag[{{ key }}] = On
+{% elif value is sameas False %}
+php_admin_flag[{{ key }}] = Off
+{% else %}
+php_admin_value[{{ key }}] = {{ value }}
+{% endif %}
+{% endfor %}
+
+{% for key, value in php7_fpm_pool_php_value.iteritems() %}
+{% if value is sameas True %}
+php_flag[{{ key }}] = On
+{% elif value is sameas False %}
+php_flag[{{ key }}] = Off
+{% else %}
+php_value[{{ key }}] = {{ value }}
+{% endif %}
+{% endfor %}

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -1,0 +1,46 @@
+[global]
+
+pid = {{ php7_fpm_pid }}
+
+error_log = {{ php7_fpm_error_log }}
+log_level = {{ php7_fpm_log_level }}
+
+{% if php7_fpm_syslog_facility is not none %}
+syslog.facility = {{ php7_fpm_syslog_facility }}
+{% endif %}
+{% if php7_fpm_syslog_ident is not none %}
+syslog.ident = {{ php7_fpm_syslog_ident }}
+{% endif %}
+
+emergency_restart_threshold = {{ php7_fpm_emergency_restart_threshold }}
+emergency_restart_interval = {{ php7_fpm_emergency_restart_interval }}
+
+process_control_timeout = {{ php7_fpm_process_control_timeout }}
+
+{% if php7_fpm_process_max is not none %}
+process.max = {{ php7_fpm_process_max }}
+{% endif %}
+{% if php7_fpm_process_priority is not none %}
+process.priority = {{ php7_fpm_process_priority }}
+{% endif %}
+
+{% if php7_fpm_daemonize %}
+daemonize = yes
+{% else %}
+daemonize = no
+{% endif %}
+
+{% if php7_fpm_rlimit_files is not none %}
+rlimit_files = {{ php7_fpm_rlimit_files }}
+{% endif %}
+{% if php7_fpm_rlimit_core is not none %}
+rlimit_core = {{ php7_fpm_rlimit_core }}
+{% endif %}
+
+{% if php7_fpm_events_mechanism is not none %}
+events.mechanism = {{ php7_fpm_events_mechanism }}
+{% endif %}
+
+systemd_interval = {{ php7_fpm_systemd_interval }}
+
+include=/etc/php/7.1/fpm/pool.d/*.conf

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -1,0 +1,11 @@
+{% for key, value in php7_ini_directives.iteritems() %}
+{% if value is sameas True %}
+{{ key }} = On
+{% elif value is sameas False %}
+{{ key }} = Off
+{% elif value is number %}
+{{ key }} = {{ value }}
+{% else %}
+{{ key }} = "{{ value }}"
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
We now use the deb.sury.org, which keeps PHP up-to-date.
We also support CLI, CGI, Apache2, FPM and dev-files in this role,
which deprecates the php7_cli, php7_dev, php7_fpm roles.

After merging, please tag the role `v1.0.0`, and update Galaxy 🙂 