### PR TITLE
Ensure "chdir" in the standard pool exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,12 @@
   notify: Restart PHP FPM
   when: php7_enable_fpm
 
+- name: Ensure "chdir" in the standard pool exists
+  file:
+    path: "{{ php7_fpm_pool_chdir }}"
+    state: directory
+  when: php7_enable_fpm and php7_fpm_pool_enabled
+
 - name: Configure the standard pool for FPM
   template:
     src: php-fpm-pool.conf.j2


### PR DESCRIPTION
This fixes the following error (on a clean Debian Stretch machine):

```
RUNNING HANDLER [f500.php7 : Restart PHP FPM] **********************************
fatal: [develop.poolz.loc]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to restart service php7.1-fpm: Job for php7.1-fpm.service failed because the control process exited with error code.\nSee \"systemctl status php7.1-fpm.service\" and \"journalctl -xe\" for details.\n"}
```

Which is caused by:

```
$ sudo cat /var/log/php7.1-fpm.log
...
[27-Sep-2017 10:33:38] ERROR: [pool www] the chdir path '/var/www' does not exist or is not a directory
```

Now, when FPM and the standard pool is enabled, this directory is created (if it doesn't exist already).

After merging, please tag as `v1.0.2`.