### PR TITLE
Use version-variable everywhere & add 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 
 All role variables are displayed with their default value.
 
-Specify the version of PHP you want to use (`7.0` or `7.1`):
+Specify the version of PHP you want to use (`7.0`, `7.1` or `7.2`):
 
     php7_version: 7.1
 
@@ -155,7 +155,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-        - { role: f500.php7, php7_version: 7.1, php7_enable_fpm: yes }
+        - { role: f500.php7, php7_version: 7.2, php7_enable_fpm: yes }
 
 License
 -------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Validate version value
   fail:
-    msg: "The value of php7_version must be 7.0 or 7.1"
-  when: php7_version not in [7.0, 7.1]
+    msg: "The value of php7_version must be 7.0, 7.1 or 7.2"
+  when: php7_version not in [7.0, 7.1, 7.2]
 
 - name: Install packages needed to use the deb.sury.org repository
   apt:

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -43,4 +43,4 @@ events.mechanism = {{ php7_fpm_events_mechanism }}
 
 systemd_interval = {{ php7_fpm_systemd_interval }}
 
-include=/etc/php/7.1/fpm/pool.d/*.conf
+include=/etc/php/{{ php7_version }}/fpm/pool.d/*.conf


### PR DESCRIPTION
- Use `php7_version` variable in FPM config (instead of hardcoded `7.1`).
- Add `7.2` to the version choices (now `7.0`, `7.1` and `7.2`).
- The default version is unchanged! (still `7.1`)