### PR TITLE
Update deb.sury.org trusted key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Add the deb.sury.org trusted key
   apt_key:
-    id: 4A7A714D
+    id: 95BD4743
     url: https://packages.sury.org/php/apt.gpg
 
 - name: Add the deb.sury.org repository


### PR DESCRIPTION
Error: key does not seem to have been added

GPG key has been changed.
source: https://www.patreon.com/posts/25451165